### PR TITLE
Improve dump handling

### DIFF
--- a/cqlsh.js
+++ b/cqlsh.js
@@ -1,0 +1,50 @@
+var child_process = require('child_process');
+
+function getCqlVersion(systemClient) {
+    return systemClient.execute("SELECT cql_version FROM system.local")
+        .then(result => result.rows[0].cql_version);
+}
+
+function runCqlsh(cqlVersion, commandStream, {user, password, host, port}) {
+    return new Promise((resolve, reject) => {
+        var done = false;
+        var stdin = commandStream;
+        if (typeof commandStream === 'string' || commandStream instanceof Buffer)
+            stdin = "pipe";
+
+        let ps = child_process.spawn(
+            "cqlsh", ["--cqlversion", cqlVersion, "-u", user, "-p", password, host, port],
+            {stdio: [stdin, "pipe", "inherit"]});
+        ps.on('error', reject);
+        ps.on('exit', code => {
+            if (code == 0 && done)
+                resolve(output);
+            else if (code == 0) {
+                done = true;
+            } else {
+                reject(new Error(`CQLSH failed with code: ${code}`));
+            }
+        });
+
+        var output = '';
+        ps.stdout.setEncoding('utf-8');
+        ps.stdout.on('data', chunk => output += chunk);
+        ps.stdout.on('end', () => {
+            if (done)
+                resolve(output);
+            else
+                done = true;
+        });
+
+        if (typeof commandStream === 'string' || commandStream instanceof Buffer) {
+            ps.stdin.setEncoding('utf-8');
+            ps.stdin.write(commandStream);
+            ps.stdin.end();
+        }
+    });
+}
+
+module.exports = {
+    getCqlVersion: getCqlVersion,
+    runCqlsh: runCqlsh
+}

--- a/import.js
+++ b/import.js
@@ -1,8 +1,14 @@
-var _ = require('lodash');
-var Promise = require('bluebird');
-var cassandra = require('cassandra-driver');
 var fs = require('fs');
+var path = require('path');
+var child_process = require('child_process');
+
+var Promise = require('bluebird');
+var _ = require('lodash');
+var cassandra = require('cassandra-driver');
 var jsonStream = require('JSONStream');
+
+const {runCqlsh, getCqlVersion} = require('./cqlsh');
+
 
 var HOST = process.env.HOST || '127.0.0.1';
 var PORT = process.env.PORT || 9042;
@@ -16,9 +22,9 @@ if (!KEYSPACE) {
 var USER = process.env.USER;
 var PASSWORD = process.env.PASSWORD;
 var DIRECTORY = process.env.DIRECTORY || "./data";
+var cqlshOptions = {user: USER, password: PASSWORD, host: HOST, port: PORT};
 
 var authProvider;
-
 if (USER && PASSWORD) {
     authProvider = new cassandra.auth.PlainTextAuthProvider(USER, PASSWORD);
 }
@@ -75,104 +81,115 @@ function buildTableQueryForDataRow(tableInfo, row) {
     };
 }
 
-function processTableImport(table) {
-    var rows = [];
-    return new Promise(function(resolve, reject) {
-        console.log('==================================================');
-        console.log('Reading metadata for table: ' + table);
-        systemClient.metadata.getTable(KEYSPACE, table)
-            .then(function (tableInfo){
-                if (!tableInfo) {
-                    resolve();
-                    return;
-                }
-
-                console.log('Creating read stream from: ' + table + '.json');
-                var jsonfile = fs.createReadStream(DIRECTORY + '/' + table + '.json', {encoding: 'utf8'});
-                var readStream = jsonfile.pipe(jsonStream.parse('*'));
-                var queryPromises = [];
-                var processed = 0;
-                readStream.on('data', function(row){
-                    var query = buildTableQueryForDataRow(tableInfo, row);
-                    queryPromises.push(client.execute(query.query, query.params, { prepare: true}));
-                    processed++;
-
-                    if (processed%1000 === 0) {
-                        console.log('Streaming ' + processed + ' rows to table: ' + table);
-                        jsonfile.pause();
-                        Promise.all(queryPromises)
-                            .then(function (){
-                                queryPromises = [];
-                                jsonfile.resume();
-                            })
-                            .catch(function (err){
-                                reject(err);
-                            });
-                    }
-
-                });
-                jsonfile.on('error', function (err) {
-                    reject(err);
-                });
-
-                var startTime = Date.now();
-                jsonfile.on('end', function () {
-                    console.log('Streaming ' + processed + ' rows to table: ' + table);
-                    Promise.all(queryPromises)
-                        .then(function (){
-                            var timeTaken = (Date.now() - startTime) / 1000;
-                            var throughput = timeTaken ? processed / timeTaken : 0.00;
-                            console.log('Done with table, throughput: ' + throughput.toFixed(1) + ' rows/s');
-                            resolve();
-                        })
-                        .catch(function (err){
-                            reject(err);
-                        });
-                });
-            })
-            .catch(function (err){
+function loadSchema(path) {
+    return new Promise((resolve, reject) => {
+        let stream = fs.createReadStream(path, {encoding: 'utf8'});
+        stream.on('open', () => resolve(stream));
+        stream.on('error', (err) => {
+            if (err.code === 'ENOENT')
+                resolve(null);
+            else {
+                console.log(`Failed to load schema at ${schemaPath}`)
                 reject(err);
-            });
+            }
+        });
     });
 }
 
-systemClient.connect()
-    .then(function (){
-        var systemQuery = "SELECT columnfamily_name as table_name FROM system.schema_columnfamilies WHERE keyspace_name = ?";
-        if (systemClient.metadata.keyspaces.system_schema) {
-            systemQuery = "SELECT table_name FROM system_schema.tables WHERE keyspace_name = ?";
-        }
+function prepareSharedSchema(path) {
+    return Promise.all([loadSchema(path), getCqlVersion(systemClient)])
+        .then(([schemaStream, cqlVersion]) => runCqlsh(cqlVersion, schemaStream, cqlshOptions))
+        .then(() => systemClient.metadata.refreshKeyspace(KEYSPACE));
+}
 
-        console.log('Finding tables in keyspace: ' + KEYSPACE);
-        return systemClient.execute(systemQuery, [KEYSPACE]);
-    })
-    .then(function (result){
-        var tables = [];
-        for(var i=0; i<result.rows.length; i++) {
-            tables.push(result.rows[i].table_name);
-        }
+function sleep (time) {
+    return new Promise((resolve) => setTimeout(resolve, time));
+}
 
-        if (process.env.TABLE) {
-            return processTableImport(process.env.TABLE);
-        }
+function prepareTable(table, schemaPath) {
+    let getSchemaStream = () => loadSchema(schemaPath);
+    let getTableMetadata = () => {
+        return systemClient.metadata.refreshKeyspace(KEYSPACE)
+            .then(() => systemClient.metadata.getTable(KEYSPACE, table));
+    };
 
-        return Promise.each(tables, function(table){
-            return processTableImport(table);
-        });
-    })
-    .then(function (){
-        console.log('==================================================');
-        var gracefulShutdown = [];
-        gracefulShutdown.push(systemClient.shutdown());
-        gracefulShutdown.push(client.shutdown());
-        Promise.all(gracefulShutdown)
-            .then(function (){
-                console.log('Completed importing to keyspace: ' + KEYSPACE);
-            })
-            .catch(function (err){
-                console.log(err);
+    return Promise.all([getSchemaStream(), getTableMetadata(), getCqlVersion(systemClient)])
+        .then(([schemaStream, tableMetadata, cqlVersion]) => {
+            if (tableMetadata && schemaStream) {
+                console.log("Recreating table: " + table);
+                return client.execute(`DROP TABLE "${KEYSPACE}"."${table}"`)
+                    .then(() => sleep(2000))
+                    .then(() => runCqlsh(cqlVersion, schemaStream, cqlshOptions))
+                    .then(() => getTableMetadata());
+            } else if (!tableMetadata && schemaStream) {
+                console.log("Creating table: " + table);
+                return runCqlsh(cqlVersion, schemaStream, cqlshOptions)
+                    .then(_ => getTableMetadata());
+            } else if (!tableMetadata && !schemaStream) {
+                throw new Exception("Table is missing, but schema is not available for recreation: " + table);
+            } else {
+                return Promise.resolve(tableMetadata);
+            }
+        })
+}
+
+
+function processTableImport(table) {
+    return prepareTable(table, DIRECTORY + '/' + table + '.cql').
+        then(tableInfo => new Promise((resolve, reject) => {
+            console.log('Creating read stream from: ' + table + '.json');
+            var jsonfile = fs.createReadStream(DIRECTORY + '/' + table + '.json', {encoding: 'utf8'});
+            var readStream = jsonfile.pipe(jsonStream.parse('*'));
+            var queryPromises = [];
+            var processed = 0;
+
+            readStream.on('data', function(row){
+                var query = buildTableQueryForDataRow(tableInfo, row);
+                queryPromises.push(client.execute(query.query, query.params, { prepare: true}));
+                processed++;
+
+                if (processed % 1000 === 0) {
+                    console.log('Streaming ' + processed + ' rows to table: ' + table);
+                    jsonfile.pause();
+                    Promise.all(queryPromises)
+                        .then(function (){
+                            queryPromises = [];
+                            jsonfile.resume();
+                        })
+                        .catch(reject);
+                }
             });
-    })
+            jsonfile.on('error', reject);
+
+            var startTime = Date.now();
+            jsonfile.on('end', function () {
+                console.log('Streaming ' + processed + ' rows to table: ' + table);
+                Promise.all(queryPromises)
+                    .then(function (){
+                        var timeTaken = (Date.now() - startTime) / 1000;
+                        var throughput = timeTaken ? processed / timeTaken : 0.00;
+                        console.log('Done with table, throughput: ' + throughput.toFixed(1) + ' rows/s');
+                        resolve();
+                    })
+                    .catch(reject);
+            });
+        }));
+}
+
+var envTables = process.env.TABLE ? process.env.TABLE.split(",") : null;
+
+var dumpTables = fs.readdirSync(DIRECTORY)
+    .filter(fname => fname.endsWith(".json"))
+    .map(fname => path.basename(fname, ".json"))
+    .filter(table => !envTables || envTables.indexOf(table) != -1);
+
+console.log(`Processing tables: ${dumpTables}`)
+
+systemClient.connect()
+    .then(() => prepareSharedSchema(DIRECTORY + '/_shared.cql'))
+    .then(() => Promise.each(dumpTables, processTableImport))
+    .then(() => Promise.all([systemClient.shutdown(), client.shutdown()]))
+    .then(() => console.log('Completed importing to keyspace: ' + KEYSPACE))
     .catch(function (err){
         console.log(err);
     });


### PR DESCRIPTION
- Export and import table schemas. Drop tables if they already exist
- Export and import shared schema resources, such as types and functions
before loading
- Don't try to import tables that are not present in a dump